### PR TITLE
Render markdown pages from community_curriculum 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "community_curriculum"]
+	path = community_curriculum
+	url = git@github.com:emmairwin/community_curriculum.git

--- a/pages/curriculum.jsx
+++ b/pages/curriculum.jsx
@@ -1,8 +1,39 @@
 var React = require('react');
 var marked = require('marked');
 var HeroUnit = require('../components/hero-unit.jsx');
+var fs = require('fs');
+var request = require('superagent');
+
+marked.setOptions({
+  renderer: new marked.Renderer(),
+  gfm: true,
+  tables: true,
+  breaks: false,
+  pedantic: false,
+  sanitize: true,
+  smartLists: true,
+  smartypants: false
+});
 
 var CurriculumPage = React.createClass({
+  getInitialState: function() {
+    if (typeof fs.readFileSync != "undefined") {
+      var content = fs.readFileSync("community_curriculum/" + this.props.contentPath, 'utf8');
+      return {
+        content: content
+      }
+    } else {
+      return {
+          content: 'Loading..'
+      }
+    }
+  },
+  componentDidMount: function() {
+    var contentPath = this.props.contentPath;
+    request.get("https://raw.githubusercontent.com/emmairwin/community_curriculum/master/" + contentPath).end(function(err, res) {
+      this.setState({content: res.text});
+  }.bind(this));
+  },
   render: function() {
     return (
       <div>
@@ -10,10 +41,7 @@ var CurriculumPage = React.createClass({
           <h1>{this.props.title}</h1>
         </HeroUnit>
         <h2>Participation Rocks.</h2>
-         <div>
-          {marked(this.props.markdown)}
-         </div>
-         {this.props.children}
+         <div dangerouslySetInnerHTML={{__html: marked(this.state.content)}} />
       </div>
     );
   }

--- a/pages/moz-participation.jsx
+++ b/pages/moz-participation.jsx
@@ -1,37 +1,18 @@
 
 var React = require('react');
-var marked = require('marked');
-
-marked.setOptions({
-  renderer: new marked.Renderer(),
-  gfm: true,
-  tables: true,
-  breaks: false,
-  pedantic: false,
-  sanitize: true,
-  smartLists: true,
-  smartypants: false
-});
-
+var fs = require('fs');
 
 var CurriculumPage = require('./curriculum.jsx');
 
+var contentPath = ("participation/design_thinking_for_participation/en/design_thinking_group.md")
+
 var ParticipationPage = React.createClass({
-  statics: {
-    pageTitle: 'Participation'
-  },
   render: function() {
-  var html = marked('I am using __markdown__.');
-  console.log(html);
-  var test = "testing one two";
     return <CurriculumPage
       title="Participation at Mozilla"
-      markdown="'I am using __markdown__."
-      test= {test}
+      contentPath={contentPath}
     />;
   }
 });
 
 module.exports = ParticipationPage;
-
-


### PR DESCRIPTION
I've added the community_curriculum as a submodule. Therefore, a `git submodule init` might be needed before running.

I've found a bug myself that when `npm start`ed, clicking on participation in sidebar once does not load the page. But clicking on it again does load it. 

Also, `npm test` fails.

These are both because we've used fs to read the file probably. I'm not sure how to fix that. Just sending this PR as because maybe someone else can work on top of it from mozilla/participation-org#121
